### PR TITLE
Viewport styling tweaks

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -32,6 +32,11 @@ header {
     display: flex;
     align-items: center;
     gap: var(--s-1);
+    padding-top: var(--s2);
+}
+
+h1 {
+    font-size: 2em;
 }
 
 .wrapper {
@@ -39,8 +44,8 @@ header {
     width: clamp(16rem, 90vw, 70rem);
     margin-left: auto;
     margin-right: auto;
-    padding-left: var(--s1, 1rem);
-    padding-right: var(--s1, 1rem);
+    padding-left: var(--s0, 1rem);
+    padding-right: var(--s0, 1rem);
     position: relative;
 }
 
@@ -62,23 +67,23 @@ header {
     align-items: center;
 }
 
-h2 {
-    font-family: var(--mt-font-heading);
-    font-size: 3em;
-    margin-top: var(--s2);
-    text-align: center;
-    letter-spacing: -2px;
+.navigation {
+    margin-bottom: var(--s2, 2.5rem);
 }
 
 .icebreaker-card {
     background-color: white;
-    width: 24rem;
-    height: 60vh;
-    height: clamp(16rem, 60vh, 32rem);
+    height: 50vh;
+    height: clamp(16rem, 50vh, 32rem);
     border-radius: 4px;
     display: flex;
     justify-content: center;
     align-items: center;
+}
+
+.icebreaker-card p {
+    max-width: 24ch;
+    font-size: 1.2em;
 }
 
 .card-content::after,
@@ -111,8 +116,6 @@ h2 {
     justify-content: center;
     align-items: center;
     text-align: center;
-    transition: all 1s ease-in-out;
-    font-size: 1.25rem;
     height: calc(100% - clamp(1rem, 4rem, 5rem));
     width: calc(100% - clamp(1rem, 4rem, 5rem));
     z-index: 0;
@@ -169,4 +172,15 @@ h2 {
     position: absolute;
     white-space: nowrap;
     width: 1px;
+}
+
+/* Media Queries */
+@media (max-width: 480px) {
+    h1 {
+        font-size: 1.5em;
+    }
+
+    .icebreaker-card p {
+        font-size: .9em;
+    }
 }

--- a/static/css/reset.css
+++ b/static/css/reset.css
@@ -1,0 +1,74 @@
+/* Box sizing rules */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+/* Remove default margin */
+body,
+h1,
+h2,
+h3,
+h4,
+p,
+figure,
+blockquote,
+dl,
+dd {
+  margin: 0;
+}
+
+/* Remove list styles on ul, ol elements with a list role, which suggests default styling will be removed */
+ul[role='list'],
+ol[role='list'] {
+  list-style: none;
+}
+
+/* Set core root defaults */
+html:focus-within {
+  scroll-behavior: smooth;
+}
+
+/* Set core body defaults */
+body {
+  min-height: 100vh;
+  text-rendering: optimizeSpeed;
+  line-height: 1.5;
+}
+
+/* A elements that don't have a class get default styles */
+a:not([class]) {
+  text-decoration-skip-ink: auto;
+}
+
+/* Make images easier to work with */
+img,
+picture {
+  max-width: 100%;
+  display: block;
+}
+
+/* Inherit fonts for inputs and buttons */
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+/* Remove all animations, transitions and smooth scroll for people that prefer not to see them */
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+   scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@800&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/reset.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 <body>
@@ -21,7 +22,7 @@
                 {% block content %}
                 {% endblock %}
             </section>
-            <section class="container">
+            <section class="container navigation">
                 {% block next %}
                 {% endblock %}
             </section>


### PR DESCRIPTION
Some small mobile styling tweaks to give more confidence that users across viewport sizes can randomise the cards properly without any obstruction from, e.g., mobile browser navigation panels

Also added a CSS reset stylesheet to ensure consistency across all browsers