### PR TITLE
Fix paragraph text width of the card to 24ch

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -82,7 +82,7 @@ h1 {
 }
 
 .icebreaker-card p {
-    max-width: 24ch;
+    width: 24ch;
     font-size: 1.2em;
 }
 


### PR DESCRIPTION
fix the width of the paragraph text to ensure text length does not influence card width. This will also not affect the overall responsiveness of the card when changing browser viewport size